### PR TITLE
Added S3 Upload workflow.

### DIFF
--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+# Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adding S3 upload to keep S3 / Cloudfront in sync when content changes.
This will also delete removed files from S3 (something we are not currently doing in Azure), causing them to 404 if accessed.
This workflow can be triggered manually, but is normally triggered by updates to the main branch.
